### PR TITLE
Solve CONDITIONAL_BARE_VARS deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - include_tasks: registries.yml
-  when: registries
+  when: registries | length > 0
 
 - include_tasks: networks.yml
-  when: networks
+  when: networks | length > 0
 
 - include_tasks: containers.yml
-  when: containers
+  when: containers | length > 0


### PR DESCRIPTION
In Ansible 2.8.6, I get a deprecation warning on `when` conditional.

> [DEPRECATION WARNING]: evaluating [] as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

Using `|bool` seems wrong. Instead, I'm checking the length of the list.